### PR TITLE
fix: fix TextCodec return type, add annotations

### DIFF
--- a/src/TextCodec.php
+++ b/src/TextCodec.php
@@ -2,6 +2,9 @@
 
 namespace Neoncitylights\Encoding;
 
+/**
+ * @see https://encoding.spec.whatwg.org/#handler
+ */
 interface TextCodec {
-	public function handler( Queue $queue, int $byteOrCodepoint ): HandleStateValue;
+	public function handler( Queue $queue, int $byteOrCodepoint ): HandleStateResult;
 }


### PR DESCRIPTION
Followup to #3 where in the PR history `HandleStateValue` was renamed to `HandleStateResult`